### PR TITLE
feat: Implement dependency injection and service layer

### DIFF
--- a/MiniServer.Core/DI/ServiceProvider.cs
+++ b/MiniServer.Core/DI/ServiceProvider.cs
@@ -1,0 +1,27 @@
+﻿
+namespace MiniServer.Core.DI;
+
+public class ServiceProvider
+{
+    private readonly Dictionary<Type, Func<object>> _services = new();
+
+    public ServiceProvider(Dictionary<Type, Func<object>> services)
+    {
+        _services = services;
+    }
+
+    public object GetService(Type type)
+    {
+        if (_services.TryGetValue(type, out var factory))
+        {
+            return factory();
+        }
+
+        var constructor = type.GetConstructors().OrderByDescending(c => c.GetParameters().Length).First();
+        var parameters = constructor.GetParameters()
+            .Select(p => GetService(p.ParameterType))
+            .ToArray();
+
+        return Activator.CreateInstance(type, parameters);
+    }
+}

--- a/MiniServer.Core/HttpServer.cs
+++ b/MiniServer.Core/HttpServer.cs
@@ -11,22 +11,14 @@ public class HttpServer
 {
     private readonly TcpListener _listener;
     private readonly int _port;
-    private readonly MiddlewarePipeline _pipeline;
+    private readonly Router _router;
 
-    public HttpServer(int port = 8080)
+    public HttpServer(Router router, int port = 8080)
     {
         _port = port;
         _listener = new TcpListener(IPAddress.Any, _port);
-
-        var router = new Router();
-        router.RegisterRoutes(Assembly.GetEntryAssembly()!);
-
-        _pipeline = new MiddlewarePipeline();
-        _pipeline.Use<LoggingMiddleware>();
         _router = router;
     }
-
-    private readonly Router _router;
 
     public async Task StartAsync()
     {
@@ -51,14 +43,26 @@ public class HttpServer
         var requestParts = requestLine.Split(' ');
         var request = new HttpRequest { Method = requestParts[0], Path = requestParts[1] };
 
+        string? line;
+        while (!string.IsNullOrEmpty(line = await reader.ReadLineAsync()))
+        {
+            var headerParts = line.Split(':', 2);
+            if (headerParts.Length == 2) request.Headers[headerParts[0]] = headerParts[1].Trim();
+        }
+
+        if (request.Headers.TryGetValue("Content-Length", out var contentLengthStr) && int.TryParse(contentLengthStr, out var contentLength))
+        {
+            var buffer = new char[contentLength];
+            await reader.ReadBlockAsync(buffer, 0, contentLength);
+            var bodyBytes = System.Text.Encoding.UTF8.GetBytes(buffer);
+            await request.Body.WriteAsync(bodyBytes, 0, bodyBytes.Length);
+            request.Body.Position = 0;
+        }
+
         var response = new HttpResponse();
         var context = new HttpContext(request, response);
 
-        var loggingMiddleware = new LoggingMiddleware();
-        await loggingMiddleware.InvokeAsync(context, async () => {
-            var routingMiddleware = new RoutingMiddleware(_router);
-            await routingMiddleware.InvokeAsync(context, () => Task.CompletedTask);
-        });
+        await _router.RouteRequestAsync(context);
 
         var responseBytes = context.Response.GetResponseBytes();
         await stream.WriteAsync(responseBytes);

--- a/MiniServer.Core/Routing/Router.cs
+++ b/MiniServer.Core/Routing/Router.cs
@@ -1,4 +1,5 @@
 ﻿using MiniServer.Core.Attributes;
+using MiniServer.Core.DI;
 using MiniServer.Core.Http;
 using System.Reflection;
 
@@ -14,7 +15,12 @@ public class RouteEntry
 public class Router
 {
     private readonly List<RouteEntry> _routes = new();
+    private readonly ServiceProvider _serviceProvider;
 
+    public Router(ServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
     public void RegisterRoutes(Assembly assembly)
     {
         var controllerTypes = assembly.GetTypes().Where(t => typeof(BaseController).IsAssignableFrom(t) && !t.IsAbstract);
@@ -48,7 +54,7 @@ public class Router
             if (routeValues != null)
             {
                 var controllerType = route.MethodInfo.DeclaringType!;
-                var controllerInstance = (BaseController)Activator.CreateInstance(controllerType)!;
+                var controllerInstance = (BaseController)_serviceProvider.GetService(controllerType);
                 controllerInstance.SetContext(context);
 
                 var methodParams = await PrepareParametersAsync(route.MethodInfo, context, routeValues);

--- a/ToDoList/Program.cs
+++ b/ToDoList/Program.cs
@@ -1,6 +1,17 @@
 ﻿using MiniServer.Core;
+using MiniServer.Core.DI;
+using MiniServer.Core.Routing;
+using System.Reflection;
+using ToDoList.Services;
 
 Console.WriteLine("Starting the ToDoList APP...");
 
-var server = new HttpServer(8080);
+var services = new Dictionary<Type, Func<object>>();
+services.Add(typeof(ITaskService), () => new TaskService());
+var serviceProvider = new ServiceProvider(services);
+
+var router = new Router(serviceProvider);
+router.RegisterRoutes(Assembly.GetExecutingAssembly());
+
+var server = new HttpServer(router, 8080);
 await server.StartAsync();

--- a/ToDoList/Services/ITaskService.cs
+++ b/ToDoList/Services/ITaskService.cs
@@ -1,0 +1,13 @@
+﻿using ToDoList.DTOs;
+using ToDoList.Models;
+
+namespace ToDoList.Services;
+
+public interface ITaskService
+{
+    List<TodoTask> GetAll();
+    TodoTask? GetById(int id);
+    TodoTask Create(CreateTaskRequest request);
+    TodoTask? Update(int id, UpdateTaskRequest request);
+    bool Delete(int id);
+}

--- a/ToDoList/Services/TaskService.cs
+++ b/ToDoList/Services/TaskService.cs
@@ -1,0 +1,50 @@
+﻿using ToDoList.DTOs;
+using ToDoList.Models;
+
+namespace ToDoList.Services;
+
+public class TaskService : ITaskService
+{
+    private static readonly List<TodoTask> _tasks = new()
+    {
+        new TodoTask { Id = 1, Title = "Learn about HTTP", IsCompleted = true },
+        new TodoTask { Id = 2, Title = "Build a Router", IsCompleted = true },
+        new TodoTask { Id = 3, Title = "Return JSON data", IsCompleted = false }
+    };
+
+    public List<TodoTask> GetAll() => _tasks;
+
+    public TodoTask? GetById(int id) => _tasks.FirstOrDefault(t => t.Id == id);
+
+    public TodoTask Create(CreateTaskRequest request)
+    {
+        var newId = _tasks.Any() ? _tasks.Max(t => t.Id) + 1 : 1;
+        var newTask = new TodoTask
+        {
+            Id = newId,
+            Title = request.Title,
+            IsCompleted = false
+        };
+        _tasks.Add(newTask);
+        return newTask;
+    }
+
+    public TodoTask? Update(int id, UpdateTaskRequest request)
+    {
+        var task = GetById(id);
+        if (task == null) return null;
+
+        task.Title = request.Title;
+        task.IsCompleted = request.IsCompleted;
+        return task;
+    }
+
+    public bool Delete(int id)
+    {
+        var task = GetById(id);
+        if (task == null) return false;
+
+        _tasks.Remove(task);
+        return true;
+    }
+}


### PR DESCRIPTION
This commit introduces a basic dependency injection (DI) container to decouple the application's components and improve testability.

- Implements a `ServiceProvider` capable of resolving dependencies and creating object instances via Reflection.
- Refactors the application logic by moving data management from the controller to a dedicated service layer (`ITaskService` / `TaskService`).
- The `Router` is now DI-aware and uses the `ServiceProvider` to create controller instances, automatically injecting their dependencies.